### PR TITLE
DBAAS-1163 Fix the loader spinning issue when fetch clusters  

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,7 +10,7 @@ const { config: webpackConfig, plugins } = config({
   appUrl: process.env.BETA
     ? '/beta/application-services/databases'
     : '/application-services/databases',
-  env: process.env.BETA ? 'prod-beta' : 'prod-stable',
+  env: process.env.BETA ? 'stage-beta' : 'stage-stable',
   standalone: Boolean(process.env.STANDALONE),
 });
 plugins.push(...commonPlugins);

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,7 +10,7 @@ const { config: webpackConfig, plugins } = config({
   appUrl: process.env.BETA
     ? '/beta/application-services/databases'
     : '/application-services/databases',
-  env: process.env.BETA ? 'stage-beta' : 'stage-stable',
+  env: process.env.BETA ? 'prod-beta' : 'prod-stable',
   standalone: Boolean(process.env.STANDALONE),
 });
 plugins.push(...commonPlugins);

--- a/src/Routes/HomePage/index.js
+++ b/src/Routes/HomePage/index.js
@@ -347,7 +347,7 @@ async function loadClusters() {
     notAROClusters.map(fetchAddonInquirues)
   );
   const clustersAvailability = clusterAddonInquirues
-    .filter(({ status }) => status === 'fulfilled')
+    .filter(({ status, value: {kind} }) => status === 'fulfilled' && kind !== 'Error')
     .reduce((acc, value) => {
       const result = getEligbleRHODAClusters(value);
       return {
@@ -357,6 +357,7 @@ async function loadClusters() {
     }, {});
   const installableClusters = clusterswithNodes.filter((cluster) => {
     if (cluster.plan?.type === 'ARO') return true;
+    if (clustersAvailability[cluster.cluster_id] === undefined) return false;
     const isVersionCorrect = cluster.metrics?.every(({ openshift_version }) =>
       semver.gt(
         semver.valid(semver.coerce(openshift_version)),

--- a/src/Routes/HomePage/index.js
+++ b/src/Routes/HomePage/index.js
@@ -347,7 +347,10 @@ async function loadClusters() {
     notAROClusters.map(fetchAddonInquirues)
   );
   const clustersAvailability = clusterAddonInquirues
-    .filter(({ status, value: {kind} }) => status === 'fulfilled' && kind !== 'Error')
+    .filter(
+      ({ status, value: { kind } }) =>
+        status === 'fulfilled' && kind !== 'Error'
+    )
     .reduce((acc, value) => {
       const result = getEligbleRHODAClusters(value);
       return {


### PR DESCRIPTION
Jira: [https://issues.redhat.com/browse/DBAAS-1163](https://issues.redhat.com/browse/DBAAS-1163)
Cause: When fetch add-on inquiries, there could be errors.
Fix: Filter out the clusters whose add-on inquires cannot be correctly fetched.