### PR TITLE
updating pull-secret to include user.identity.internal.account_id

### DIFF
--- a/src/hooks/pull-secret.tsx
+++ b/src/hooks/pull-secret.tsx
@@ -111,7 +111,7 @@ export const useDownloadPullSecret = () => {
     const pullSecret: PullSecret = {
       ...accessToken,
       orgId: user.identity.org_id,
-      userId: user.identity.account_number,
+      userId: user.identity.internal.account_id,
     };
 
     const rawPullSecret = new Blob([JSON.stringify(pullSecret)], {


### PR DESCRIPTION
Updating because we need access to the `rhit_web_user_id` value. High Priority.